### PR TITLE
chore: bump @grafana/create-plugin configuration to 6.7.5

### DIFF
--- a/.config/.cprc.json
+++ b/.config/.cprc.json
@@ -1,4 +1,4 @@
 {
-  "version": "6.6.0",
+  "version": "6.7.5",
   "features": {}
 }


### PR DESCRIPTION
Bumps [`@grafana/create-plugin`](https://github.com/grafana/plugin-tools/tree/main/packages/create-plugin) configuration from 6.6.0 to 6.7.5.

**Notes for reviewer:**
This is an auto-generated PR which ran `@grafana/create-plugin update`.
Please consult the create-plugin [CHANGELOG.md](https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/CHANGELOG.md) to understand what may have changed.
Please review the changes thoroughly before merging.